### PR TITLE
feat:Fix parameter comparison and return optimization in ExecutableEl…

### DIFF
--- a/microsphere-annotation-processor/src/main/java/io/microsphere/annotation/processor/util/ExecutableElementComparator.java
+++ b/microsphere-annotation-processor/src/main/java/io/microsphere/annotation/processor/util/ExecutableElementComparator.java
@@ -54,7 +54,7 @@ public class ExecutableElementComparator implements Comparator<ExecutableElement
         if (value == 0) { // Step 2
 
             List<? extends VariableElement> ps1 = e1.getParameters();
-            List<? extends VariableElement> ps2 = e1.getParameters();
+            List<? extends VariableElement> ps2 = e2.getParameters();
 
             value = ps1.size() - ps2.size();
 
@@ -67,6 +67,6 @@ public class ExecutableElementComparator implements Comparator<ExecutableElement
                 }
             }
         }
-        return Integer.compare(value, 0);
+        return value;
     }
 }


### PR DESCRIPTION
### 修复 ExecutableElementComparator 中的参数比较错误

**问题描述**：
在 `ExecutableElementComparator` 类的 `compare` 方法中，存在一个错误，原本应该比较 `e1` 和 `e2` 的参数，但错误地比较了 `e1` 的参数两次。

**解决方案**：
修复了这个错误，并进行了简化，提高了方法的效率。

**改动详情**：
- 修复了 `compare` 方法中的参数比较错误。
- 简化了 `compare` 方法的返回值处理。