### PR TITLE
Sync dev code

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11' , '17' , '21' ]
+        java: [ '8', '11' , '17' , '21' , '25' ]
     steps:
       - name: Checkout Source
         uses: actions/checkout@v4

--- a/microsphere-annotation-processor/src/test/java/io/microsphere/annotation/processor/TestAnnotation.java
+++ b/microsphere-annotation-processor/src/test/java/io/microsphere/annotation/processor/TestAnnotation.java
@@ -22,12 +22,12 @@ import io.microsphere.annotation.Since;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.concurrent.TimeUnit.DAYS;
 
 /**
@@ -37,8 +37,8 @@ import static java.util.concurrent.TimeUnit.DAYS;
  * @see Annotation
  * @since 1.0.0
  */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
+@Retention(RUNTIME)
+@Target(TYPE)
 @Documented
 public @interface TestAnnotation {
 

--- a/microsphere-java-core/src/main/java/io/microsphere/util/ClassPathUtils.java
+++ b/microsphere-java-core/src/main/java/io/microsphere/util/ClassPathUtils.java
@@ -35,7 +35,7 @@ import static java.util.Collections.emptySet;
  *     <li>Locating the runtime URL of a class by name or type</li>
  * </ul>
  *
- * <h3>Example Usage:</h3>
+ * <h3>Example Usage</h3>
  * <pre>{@code
  * // Get all application class paths
  * Set<String> classPaths = ClassPathUtils.getClassPaths();

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     </scm>
 
     <properties>
-        <revision>0.1.5-SNAPSHOT</revision>
+        <revision>0.1.6-SNAPSHOT</revision>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request introduces minor improvements and updates across the project, focusing on supporting the latest Java version, refining annotation usage, and preparing for the next release. The most important changes are grouped below:

Java version support:

* Added Java 25 to the build matrix in `.github/workflows/maven-build.yml`, ensuring CI/CD compatibility with the latest Java release.

Annotation usage refinement:

* Updated `TestAnnotation.java` to use static imports for `ElementType.TYPE` and `RetentionPolicy.RUNTIME`, making the annotation declarations more concise and idiomatic.
* Changed the annotation declarations in `TestAnnotation.java` to use the imported static constants, improving readability.

Release preparation:

* Bumped the project version in `pom.xml` from `0.1.5-SNAPSHOT` to `0.1.6-SNAPSHOT` in preparation for the next development cycle.

Documentation consistency:

* Removed an unnecessary colon from the "Example Usage" section in the Javadoc of `ClassPathUtils.java` for consistency.