### PR TITLE
Refactor ArtifactDetector API and enhance version detection

### DIFF
--- a/microsphere-java-core/src/main/java/io/microsphere/classloading/ArtifactDetector.java
+++ b/microsphere-java-core/src/main/java/io/microsphere/classloading/ArtifactDetector.java
@@ -6,17 +6,21 @@ import io.microsphere.annotation.Nullable;
 import io.microsphere.lang.Prioritized;
 import io.microsphere.logging.Logger;
 
+import java.io.File;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import static io.microsphere.collection.CollectionUtils.isEmpty;
+import static io.microsphere.collection.CollectionUtils.size;
+import static io.microsphere.collection.ListUtils.newArrayList;
+import static io.microsphere.lang.function.ThrowableSupplier.execute;
 import static io.microsphere.logging.LoggerFactory.getLogger;
+import static io.microsphere.net.URLUtils.resolveArchiveFile;
 import static io.microsphere.util.ClassLoaderUtils.findAllClassPathURLs;
 import static io.microsphere.util.ClassLoaderUtils.getClassLoader;
+import static io.microsphere.util.ClassLoaderUtils.getClassResource;
 import static io.microsphere.util.ClassPathUtils.getBootstrapClassPaths;
 import static io.microsphere.util.ServiceLoaderUtils.loadServicesList;
 import static io.microsphere.util.SystemUtils.JAVA_HOME;
@@ -108,24 +112,45 @@ public class ArtifactDetector {
 
     @Nonnull
     @Immutable
-    protected List<Artifact> detect(Set<URL> classPathURLs) {
-        if (isEmpty(classPathURLs)) {
+    public List<Artifact> detect(@Nullable Set<URL> resourceURLs) {
+        int size = size(resourceURLs);
+        if (size < 1) {
             return emptyList();
         }
-
-        List<Artifact> artifactList = new LinkedList<>();
-        for (URL resourceURL : classPathURLs) {
-            for (ArtifactResourceResolver artifactResourceResolver : artifactResourceResolvers) {
-                Artifact artifact = artifactResourceResolver.resolve(resourceURL);
-                if (artifact != null) {
-                    artifactList.add(artifact);
-                    break;
-                }
+        List<Artifact> artifactList = newArrayList(size);
+        for (URL resourceURL : resourceURLs) {
+            Artifact artifact = detect(resourceURL);
+            if (artifact != null) {
+                artifactList.add(artifact);
+                break;
             }
         }
-
         return unmodifiableList(artifactList);
     }
+
+    @Nullable
+    public Artifact detect(@Nonnull Class<?> classInResource) {
+        URL classResource = getClassResource(classInResource);
+        return detect(classResource);
+    }
+
+    @Nullable
+    public Artifact detect(@Nonnull URL resourceURL) {
+        File archiveFile = resolveArchiveFile(resourceURL);
+        if (archiveFile == null) {
+            return null;
+        }
+        URL classPathURL = execute(archiveFile.toURI()::toURL);
+        Artifact artifact = null;
+        for (ArtifactResourceResolver artifactResourceResolver : artifactResourceResolvers) {
+            artifact = artifactResourceResolver.resolve(classPathURL);
+            if (artifact != null) {
+                break;
+            }
+        }
+        return artifact;
+    }
+
 
     protected Set<URL> getClassPathURLs(boolean includedJdkLibraries) {
         Set<URL> urls = findAllClassPathURLs(classLoader);

--- a/microsphere-java-core/src/main/java/io/microsphere/util/Version.java
+++ b/microsphere-java-core/src/main/java/io/microsphere/util/Version.java
@@ -19,6 +19,8 @@ package io.microsphere.util;
 import io.microsphere.annotation.Immutable;
 import io.microsphere.annotation.Nonnull;
 import io.microsphere.annotation.Nullable;
+import io.microsphere.classloading.Artifact;
+import io.microsphere.classloading.ArtifactDetector;
 
 import java.io.Serializable;
 import java.net.URL;
@@ -108,7 +110,6 @@ public class Version implements Comparable<Version>, Serializable {
      * }</pre>
      *
      * @param major the major version number
-     * @since 1.0.0
      */
     public Version(int major) {
         this(major, 0);
@@ -125,7 +126,6 @@ public class Version implements Comparable<Version>, Serializable {
      *
      * @param major the major version number
      * @param minor the minor version number
-     * @since 1.0.0
      */
     public Version(int major, int minor) {
         this(major, minor, 0);
@@ -142,7 +142,6 @@ public class Version implements Comparable<Version>, Serializable {
      * @param major the major version number
      * @param minor the minor version number
      * @param patch the patch version number
-     * @since 1.0.0
      */
     public Version(int major, int minor, int patch) {
         this(major, minor, patch, null);
@@ -161,7 +160,6 @@ public class Version implements Comparable<Version>, Serializable {
      * @param patch      the patch version number (must be non-negative)
      * @param preRelease the optional pre-release identifier (e.g., "SNAPSHOT", "alpha")
      * @throws IllegalArgumentException if major, minor, or patch is negative, or all are zero
-     * @since 1.0.0
      */
     public Version(int major, int minor, int patch, String preRelease) {
         assertTrue(major >= 0, "The 'major' version must not be a non-negative integer!");
@@ -342,7 +340,6 @@ public class Version implements Comparable<Version>, Serializable {
      * }</pre>
      *
      * @return a hash code value for this version
-     * @since 1.0.0
      */
     @Override
     public int hashCode() {
@@ -368,8 +365,7 @@ public class Version implements Comparable<Version>, Serializable {
      *
      * @param that the version to compare against
      * @return a negative integer, zero, or a positive integer as this version
-     *         is less than, equal to, or greater than the specified version
-     * @since 1.0.0
+     * is less than, equal to, or greater than the specified version
      */
     @Override
     public int compareTo(Version that) {
@@ -424,7 +420,6 @@ public class Version implements Comparable<Version>, Serializable {
      * }</pre>
      *
      * @return the version string
-     * @since 1.0.0
      */
     @Override
     public String toString() {
@@ -441,7 +436,6 @@ public class Version implements Comparable<Version>, Serializable {
      *
      * @param major the major version number
      * @return a new {@link Version} instance
-     * @since 1.0.0
      */
     public static Version of(int major) {
         return ofVersion(major);
@@ -458,7 +452,6 @@ public class Version implements Comparable<Version>, Serializable {
      * @param major the major version number
      * @param minor the minor version number
      * @return a new {@link Version} instance
-     * @since 1.0.0
      */
     public static Version of(int major, int minor) {
         return ofVersion(major, minor);
@@ -476,7 +469,6 @@ public class Version implements Comparable<Version>, Serializable {
      * @param minor the minor version number
      * @param patch the patch version number
      * @return a new {@link Version} instance
-     * @since 1.0.0
      */
     public static Version of(int major, int minor, int patch) {
         return ofVersion(major, minor, patch);
@@ -495,7 +487,6 @@ public class Version implements Comparable<Version>, Serializable {
      * @param patch      the patch version number
      * @param preRelease the pre-release identifier
      * @return a new {@link Version} instance
-     * @since 1.0.0
      */
     public static Version of(int major, int minor, int patch, String preRelease) {
         return ofVersion(major, minor, patch, preRelease);
@@ -514,7 +505,6 @@ public class Version implements Comparable<Version>, Serializable {
      * @param version the version string to parse
      * @return a new {@link Version} instance
      * @throws IllegalArgumentException if the version string is null, blank, or invalid
-     * @since 1.0.0
      */
     public static Version of(String version) {
         return ofVersion(version);
@@ -530,7 +520,6 @@ public class Version implements Comparable<Version>, Serializable {
      *
      * @param major the major version number
      * @return a new {@link Version} instance
-     * @since 1.0.0
      */
     public static Version ofVersion(int major) {
         return new Version(major);
@@ -547,7 +536,6 @@ public class Version implements Comparable<Version>, Serializable {
      * @param major the major version number
      * @param minor the minor version number
      * @return a new {@link Version} instance
-     * @since 1.0.0
      */
     public static Version ofVersion(int major, int minor) {
         return new Version(major, minor);
@@ -565,7 +553,6 @@ public class Version implements Comparable<Version>, Serializable {
      * @param minor the minor version number
      * @param patch the patch version number
      * @return a new {@link Version} instance
-     * @since 1.0.0
      */
     public static Version ofVersion(int major, int minor, int patch) {
         return new Version(major, minor, patch);
@@ -584,7 +571,6 @@ public class Version implements Comparable<Version>, Serializable {
      * @param patch      the patch version number
      * @param preRelease the pre-release identifier
      * @return a new {@link Version} instance
-     * @since 1.0.0
      */
     public static Version ofVersion(int major, int minor, int patch, String preRelease) {
         return new Version(major, minor, patch, preRelease);
@@ -604,7 +590,6 @@ public class Version implements Comparable<Version>, Serializable {
      * @param version the version string to parse
      * @return a new {@link Version} instance
      * @throws IllegalArgumentException if the version string is null, blank, or contains non-numeric parts
-     * @since 1.0.0
      */
     public static Version ofVersion(String version) {
         assertNotNull(version, () -> "The 'version' argument must not be null!");
@@ -622,6 +607,27 @@ public class Version implements Comparable<Version>, Serializable {
         int patch = size > 2 ? getValue(majorAndMinorAndPatch[2]) : 0;
 
         return of(major, minor, patch, preRelease);
+    }
+
+    /**
+     * Creates a {@link Version} by detecting the version from the artifact containing the specified class.
+     * This method uses {@link ArtifactDetector} to locate the artifact and retrieve its version.
+     *
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     *   Version version = Version.ofVersion(MyClass.class); // e.g., 1.0.0
+     * }</pre>
+     *
+     * @param classInResource the class contained in the artifact whose version is to be detected
+     * @return a new {@link Version} instance
+     */
+    public static Version ofVersion(@Nonnull Class<?> classInResource) {
+        assertNotNull(classInResource, () -> "The 'classInResource' argument must not be null!");
+        ClassLoader classLoader = classInResource.getClassLoader();
+        ArtifactDetector detector = new ArtifactDetector(classLoader);
+        Artifact artifact = detector.detect(classInResource);
+        String version = artifact.getVersion();
+        return ofVersion(version);
     }
 
     /**

--- a/microsphere-java-core/src/test/java/io/microsphere/classloading/ArtifactDetectorTest.java
+++ b/microsphere-java-core/src/test/java/io/microsphere/classloading/ArtifactDetectorTest.java
@@ -20,11 +20,19 @@ package io.microsphere.classloading;
 import io.microsphere.LoggingTest;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nonnull;
+import java.net.URL;
 import java.util.List;
 
+import static io.microsphere.AbstractTestCase.TEST_NULL_SET;
+import static io.microsphere.collection.Sets.ofSet;
+import static io.microsphere.net.URLUtils.ofURL;
 import static io.microsphere.util.ClassLoaderUtils.getDefaultClassLoader;
 import static java.util.Collections.emptySet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -44,15 +52,40 @@ class ArtifactDetectorTest extends LoggingTest {
     }
 
     @Test
+    void testDetectOnClassInResource() {
+        ArtifactDetector instance = new ArtifactDetector();
+        assertThrows(NullPointerException.class, () -> instance.detect((Class) null));
+
+        Artifact artifact = instance.detect(ArtifactDetector.class);
+        assertNull(artifact);
+
+        artifact = instance.detect(Nonnull.class);
+        assertNotNull(artifact);
+        assertEquals("jsr305", artifact.getArtifactId());
+        assertEquals("3.0.2", artifact.getVersion());
+    }
+
+    @Test
+    void testDetectOnResourceURL() {
+        ArtifactDetector instance = new ArtifactDetector();
+        assertThrows(NullPointerException.class, () -> instance.detect((URL) null));
+
+        URL url = ofURL("file:///not-found");
+        Artifact artifact = instance.detect(url);
+        assertNull(artifact);
+    }
+
+    @Test
     void testDetectOnNullSet() {
         ArtifactDetector instance = new ArtifactDetector(getDefaultClassLoader());
-        assertTrue(instance.detect(null).isEmpty());
+        assertTrue(instance.detect(TEST_NULL_SET).isEmpty());
     }
 
     @Test
     void testDetectOnEmptySet() {
         ArtifactDetector instance = new ArtifactDetector(null);
         assertTrue(instance.detect(emptySet()).isEmpty());
+        assertTrue(instance.detect(ofSet(ofURL("file:///not-found"))).isEmpty());
     }
 
     @Test

--- a/microsphere-java-core/src/test/java/io/microsphere/util/VersionTest.java
+++ b/microsphere-java-core/src/test/java/io/microsphere/util/VersionTest.java
@@ -18,6 +18,8 @@ package io.microsphere.util;
 
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
+
 import static io.microsphere.constants.SymbolConstants.DOT;
 import static io.microsphere.constants.SymbolConstants.HYPHEN;
 import static io.microsphere.constants.SymbolConstants.SPACE;
@@ -115,6 +117,12 @@ class VersionTest {
         assertEquals(MAJOR, version.getMajor());
         assertEquals(MINOR, version.getMinor());
         assertEquals(PATCH, version.getPatch());
+    }
+
+    @Test
+    void testOfVersionOnClassInResource() {
+        Version version = ofVersion(Nullable.class);
+        assertEquals("3.0.2", version.toString());
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces enhancements to artifact and version detection in the `microsphere-java-core` project, focusing on making artifact resolution more flexible and enabling version detection directly from classes. It also improves test coverage for these new features. The most significant changes are grouped below:

### Artifact and Version Detection Enhancements

* Refactored `ArtifactDetector` to add new overloads of the `detect` method, allowing detection of artifacts from a single `Class<?>` or `URL` in addition to a set of URLs. These methods internally resolve the archive file and use all available `ArtifactResourceResolver`s. (`microsphere-java-core/src/main/java/io/microsphere/classloading/ArtifactDetector.java`)
* Added a new static method `Version.ofVersion(Class<?> classInResource)` to detect the version of the artifact containing a specific class, using the new `ArtifactDetector.detect(Class<?>)` method. (`microsphere-java-core/src/main/java/io/microsphere/util/Version.java`)

### Test Coverage Improvements

* Added unit tests for the new `ArtifactDetector.detect(Class<?>)` and `ArtifactDetector.detect(URL)` methods, including edge cases (nulls, not-found resources, and successful detection). (`microsphere-java-core/src/test/java/io/microsphere/classloading/ArtifactDetectorTest.java`)
* Added a test for the new `Version.ofVersion(Class<?>)` method, verifying correct version detection from an annotation class. (`microsphere-java-core/src/test/java/io/microsphere/util/VersionTest.java`)

### Code Clean-up

* Removed redundant `@since 1.0.0` tags from Javadoc comments in `Version.java` for brevity and clarity. (`microsphere-java-core/src/main/java/io/microsphere/util/Version.java`) [[1]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L111) [[2]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L128) [[3]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L145) [[4]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L164) [[5]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L345) [[6]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L372) [[7]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L427) [[8]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L444) [[9]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L461) [[10]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L479) [[11]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L498) [[12]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L517) [[13]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L533) [[14]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L550) [[15]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L568) [[16]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L587) [[17]](diffhunk://#diff-b8e4b6390a646aa4cdf77e817bfcb74c18d817f129cc92aeb999f9df97aaeae0L607)

These changes make artifact and version detection more robust and user-friendly, while also ensuring the new functionality is well-tested.